### PR TITLE
Updated GUI labels

### DIFF
--- a/GUI_TekkenMovesetEditor.py
+++ b/GUI_TekkenMovesetEditor.py
@@ -58,11 +58,15 @@ fieldLabels = {
     'u8': 'head? (u8)',
     'u10': 'airborne_start',
     'u11': 'airborne_end',
+    'u12': 'ground_fall',
     'u16': 'collision? (u16)',
     'u17': 'distance (u17)',
     'anim_max_len': 'anim_len',
     'standing': 'default',
     'type': 'starting_frame',
+    'val1': 'duration',
+    'val2': 'displacement',
+    'val3': 'num of loop'
 }
 
 moveFields = {

--- a/GUI_TekkenMovesetEditor.py
+++ b/GUI_TekkenMovesetEditor.py
@@ -66,7 +66,7 @@ fieldLabels = {
     'type': 'starting_frame',
     'val1': 'duration',
     'val2': 'displacement',
-    'val3': 'num of loop'
+    'val3': 'num of loops'
 }
 
 moveFields = {


### PR DESCRIPTION
"u12" is the frame number at which you fall on the ground (cross referenced it with Sadamitsu).
"val3" value is always a multiple of 4 except it's default value, which is 1. It loops pushback (val3)/8 times.
I wanted to try changing the 'value' label in the Extradata Pushback editor too but it seems that would require more than just adding entries in the field labels. Pushback extradata value is the horizontal offset. Centre for that is the player. +ve puts opp. in front of you. -ve behind you.