### PR TITLE
Fixed "input_sequence" idx display

### DIFF
--- a/GUI_TekkenMovesetEditor.py
+++ b/GUI_TekkenMovesetEditor.py
@@ -428,7 +428,7 @@ def getCommandStr(commandBytes):
             (32772): " Double tap D",
         }.get(directionBits, "UNKNOWN")
     elif directionBits <= 36863:
-        direction = " input_sequence[%d]" % directionBits - 0x800d
+        direction = " input_sequence[%d]" % (directionBits - 0x800d)
         
     if (inputBits & (1 << 29)): # if "Partial Input" mode, replace (+) with pipe (|)
         inputs = inputs[0] + inputs[1:].replace('+', ' | ', inputs.count('+'))

--- a/InterfaceData/editorProperties.txt
+++ b/InterfaceData/editorProperties.txt
@@ -14,7 +14,7 @@
 0x8019,Elecric Effect (self)
 0x801a,Elecric Effect (opponent)
 0x801b,Rage Drive VFX
-0x801e,Mouth fog VFX
+0x801e,Mouth Fog VFX
 0x8021,Hit spark (self)
 0x8023,Hit spark (opponent)
 0x802e,Char hit spark (self)
@@ -70,22 +70,22 @@
 0x80c3,Add Chloe points
 0x80c4,Sub Chloe points
 0x80c5,Value Store (2D cancel|uses req 346)
-0x80c6,Add value to 0x80c5
-0x80c7,Sub value from 0x80c5
+0x80c6,Add to 0x80c5
+0x80c7,Sub from 0x80c5
 0x80ed,Store Combo Route Value
 0x8106,Activate Player Flag
-0x8107,Add value to (0x8106)
-0x8108,Sub value from (0x8106)
+0x8107,Add value to 0x8106
+0x8108,Sub value from 0x8106
 0x8109,Activate Opponent Flag
-0x810a,Add value to (0x8109)
-0x810b,Sub value from (0x8109)
+0x810a,Add value to 0x8109
+0x810b,Sub value from 0x8109
 0x817c,Allow player to block
 0x817d,Give CH property
 0x8181,Stop pushback
 0x818a,Add Tracking/Alignment
 0x818c,Change player status/vulnerability
 0x818e,Change collision status
-0x8193,Footstep VFX+SFX
+0x8193,Footstep SFX + VFX
 0x81a7,Align Player To Wall (?)
 0x81ad,Reset player position
 0x81bd,Power Crush
@@ -102,8 +102,8 @@
 0x81e0,Blending duration
 0x81e4,Break floor
 0x81e8,Pushback-related
-0x81ec,Enable gravity
-0x81f3,Enable laser
+0x81ec,Set Gravity (0/1)
+0x81f3,Activate laser
 0x81f4,Disable laser
 0x81fe,Reset upwards vector
 0x81ff,Slide player
@@ -151,6 +151,7 @@
 0x829f,Play subtitles
 0x82a0,Skin shine effect
 0x82ae,Noctis warp effect
+0x82bf,Assist Button Pressed VFX
 0x82c8,Use fake frame advantage
 0x82c9,Use fake startup frame
 0x82ca,Startup frames related (?)
@@ -166,6 +167,7 @@
 0x8330,Projectile hit recovery
 0x8331,Projectile grounded reaction list
 0x8332,Projectile airborne reaction list
+0x8333,Set limb for attaching item
 0x8336,Projectile 30 degrees flag
 0x8337,Projectile horizontal speed
 0x8338,Projectile vertical speed
@@ -174,7 +176,7 @@
 0x8343,Attach item to limb
 0x8344,Detach item to limb
 0x837e,Select limb to resize
-0x837f,Resize player
+0x837f,Resize player/limb
 0x83c2,Set opponent's floor level
 0x83c3,Set opponent's move
 0x83c4,Force new default stance (32768)
@@ -245,7 +247,11 @@
 0x8405,Restore alias (32800)
 0x8406,Rotate Player
 0x8407,Put opponent next to player
+0x840f,Play midbattle cutscene
 0x8410,Story Power Crush
+0x8414,Store Assist Combo Value
+0x8415,Add to 0x8414
+0x8416,Sub from 0x8414
 0x8428,Both Hands pose
 0x8429,Left hand pose
 0x842a,Right hand pose

--- a/InterfaceData/editorProperties.txt
+++ b/InterfaceData/editorProperties.txt
@@ -14,6 +14,7 @@
 0x8019,Elecric Effect (self)
 0x801a,Elecric Effect (opponent)
 0x801b,Rage Drive VFX
+0x801e,Mouth fog VFX
 0x8021,Hit spark (self)
 0x8023,Hit spark (opponent)
 0x802e,Char hit spark (self)
@@ -69,6 +70,8 @@
 0x80c3,Add Chloe points
 0x80c4,Sub Chloe points
 0x80c5,Value Store (2D cancel|uses req 346)
+0x80c6,Add value to 0x80c5
+0x80c7,Sub value from 0x80c5
 0x80ed,Store Combo Route Value
 0x8106,Activate Player Flag
 0x8107,Add value to (0x8106)
@@ -82,6 +85,7 @@
 0x818a,Add Tracking/Alignment
 0x818c,Change player status/vulnerability
 0x818e,Change collision status
+0x8193,Footstep VFX+SFX
 0x81a7,Align Player To Wall (?)
 0x81ad,Reset player position
 0x81bd,Power Crush
@@ -98,8 +102,10 @@
 0x81e0,Blending duration
 0x81e4,Break floor
 0x81e8,Pushback-related
-0x81f3,Activate laser
+0x81ec,Enable gravity
+0x81f3,Enable laser
 0x81f4,Disable laser
+0x81fe,Reset upwards vector
 0x81ff,Slide player
 0x8200,Rotate player axis
 0x8205,Push player in z-axis
@@ -126,6 +132,7 @@
 0x824d,AI input
 0x8251,Player visibility
 0x8255,Spend screw
+0x8257,Extend left shoulder hurtbox
 0x8262,wing flap anim
 0x826a,Homing (Left Hand)
 0x826b,Homing (Right Hand)

--- a/InterfaceData/editorRequirements.txt
+++ b/InterfaceData/editorRequirements.txt
@@ -98,7 +98,7 @@
 253,Bryan taunt value >= param
 255,Value (prop 0x807c) >= param
 256,Bryan taunted
-284,
+284,Player flag (0x8106) >= param
 308,Chloe Points <= param
 329,Check value (prop 0x807c)
 344,Kazuya Devil Form

--- a/InterfaceData/editorRequirements.txt
+++ b/InterfaceData/editorRequirements.txt
@@ -25,15 +25,15 @@
 28,Airborne Throw Hit (Backward)
 29,Airborne Throw Hit (Left Side)
 30,Airborne Throw Hit (Right Side)
-35,Opponent distance smaller or equal
-36,Opponent distance greater or equal
+35,Opponent distance <= param
+36,Opponent distance >= param
 43,On Hit
 44,On Hit
 47,On block
 48,On whiff
 49,On hit/block
 51,On hit
-61,Downed Opponent Face(up/down)
+61,Check opponent VULN
 66,Opponent Standing
 67,Opponent Crouching
 68,Incoming high attack
@@ -86,19 +86,20 @@
 176,Geese in Max-Mode
 177,Throwbreak On(?)
 182,Near Wall
+216,Something wallsplat related
 217,Player character ID
 218,Player NOT character ID
 219,Opponent character ID
 220,Opponent NOT character ID
 221,Player character ID
-222,Player NOT character ID
+222,Player NOT Character ID
 223,Opponent character ID
 224,Opponent NOT character ID
 225,Player is CPU
 253,Bryan taunt value >= param
 255,Value (prop 0x807c) >= param
 256,Bryan taunted
-284,Player flag (0x8106) >= param
+284,Player Flag (prop 0x8106) >= param
 308,Chloe Points <= param
 329,Check value (prop 0x807c)
 344,Kazuya Devil Form
@@ -106,11 +107,12 @@
 346,Check value (prop 0x80c5)
 351,Claudio Starburst
 352,Check value (prop 0x80a6)
-359,Check value (prop 0x8106)
+353,Check value (prop 0x80a9)
+359,Check player flag (prop 0x8106)
 361,Check value (prop 0x80ed)
-532,Check Player speed(?)
-533,Check Player speed(?)
-534,Check Player speed(?)
+532,Player speed >= param
+533,Player speed <= param
+534,Player speed == param
 552,Random number generator (uniform)
 553,Random number generator (weighted)
 558,Story Battle
@@ -130,12 +132,15 @@
 615,Screw available
 629,Meter >= param
 634,Treasure Battle Special Match
+636,Assist button pressed
 637,Check Match Point
 639,Parry Zoom
 641,Once per match (Leroy Cane)
 765,Arcade Cutscene
 785,Projectile on-hit
 786,Projectile on-block
+809,Check value (prop 0x8414)
+811,Basic combo enabled
 813,Parry high
 814,Parry mid
 815,Parry low

--- a/InterfaceData/editorRequirements.txt
+++ b/InterfaceData/editorRequirements.txt
@@ -27,6 +27,7 @@
 30,Airborne Throw Hit (Right Side)
 35,Opponent distance smaller or equal
 36,Opponent distance greater or equal
+43,On Hit
 44,On Hit
 47,On block
 48,On whiff
@@ -90,14 +91,14 @@
 219,Opponent character ID
 220,Opponent NOT character ID
 221,Player character ID
-222,Player NOT Character ID
+222,Player NOT character ID
 223,Opponent character ID
 224,Opponent NOT character ID
 225,Player is CPU
 253,Bryan taunt value >= param
 255,Value (prop 0x807c) >= param
 256,Bryan taunted
-284,Player Flag (prop 0x8106) >= param
+284,
 308,Chloe Points <= param
 329,Check value (prop 0x807c)
 344,Kazuya Devil Form
@@ -105,8 +106,7 @@
 346,Check value (prop 0x80c5)
 351,Claudio Starburst
 352,Check value (prop 0x80a6)
-353,Check value (prop 0x80a9)
-359,Check player flag (prop 0x8106)
+359,Check value (prop 0x8106)
 361,Check value (prop 0x80ed)
 532,Check Player speed(?)
 533,Check Player speed(?)


### PR DESCRIPTION
I missed a pair of parenthesis which broke Editor Sequence display. Quickly fixed that and added more editor labels.